### PR TITLE
Preserved Encoding of &lt; and &gt;

### DIFF
--- a/lib/converters/markdownDefinitions/textFormatting.js
+++ b/lib/converters/markdownDefinitions/textFormatting.js
@@ -11,6 +11,9 @@ module.exports.quote = function(text){
 };
 
 module.exports.code = function(text){
+	text = text.replace(/&lt;/g,'<');
+	text = text.replace(/&gt;/g,'>');
+	
 	if((/`/).test(text))
 		text = '`'+text+'`';
 

--- a/lib/utils/textFormatter.js
+++ b/lib/utils/textFormatter.js
@@ -23,6 +23,8 @@ var generateRegexReplacements = function() {
 
 var replacements = {
   '#' : '\\#',
+  '<' : '&lt;',
+  '>' : '&gt;',
   '([0-9])\\.(\\s|$)': '$1\\.$2',
   '\u00a9': '(c)',
   '\u00ae': '(r)',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hammerdown",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "main": "index.js",
   "description": "Streaming HTML To Markdown Writer",
   "homepage": "https://github.com/tjchaplin/hammerdown",

--- a/test/spec/markdown-testsuite/tests/html-encoded-characters.md
+++ b/test/spec/markdown-testsuite/tests/html-encoded-characters.md
@@ -1,0 +1,1 @@
+&lt;ENTER&gt;

--- a/test/spec/markdown-testsuite/tests/html-encoded-characters.out
+++ b/test/spec/markdown-testsuite/tests/html-encoded-characters.out
@@ -1,0 +1,1 @@
+<p>&lt;ENTER&gt;</p>


### PR DESCRIPTION
Fixes #4 

The underlying parser (sax)[https://github.com/isaacs/sax-js] encodes `&lt;` and `&gt;`.  The issue was fixed by:
- Re-encoding the characters when parsing text
- Adding logic to encode `&lt;` and `&gt;` when <code> is used.
  This means when HTML is: `<code>&lt;SOMETHING&gt;</code>` => `<SOMETHING>`
